### PR TITLE
update authors for gugod and shelling

### DIFF
--- a/sites/tw/authors.txt
+++ b/sites/tw/authors.txt
@@ -1,2 +1,3 @@
 szabgab;Gabor Szabo;szabgab.png;https://plus.google.com/102810219707784087582
-gugod;Kang-min Liu;gugod.png;https://plus.google.com/118077021111350586131/posts
+gugod;Kang-min Liu;gugod.png;https://plus.google.com/118077021111350586131
+shelling;Shelling Ford;shelling.png;https://plus.google.com/113634082684193579669


### PR DESCRIPTION
I wonder if it's ok to use URLs other then G+ profile page ? Since @shelling and I are not really updating status there that often.
