### PR TITLE
(Korean) fix invalid link

### DIFF
--- a/sites/ko/pages/perl-tutorial.tt
+++ b/sites/ko/pages/perl-tutorial.tt
@@ -17,7 +17,7 @@
 <b>소개</b>
 <ol>
 <li><a href="/perl-editor">Perl 에디터</a></li>
-<li><a href="/perl-on-the-command-line.tt">명령줄에서의 Perl</a></li>
+<li><a href="/perl-on-the-command-line">명령줄에서의 Perl</a></li>
 <li><a href="/pod-plain-old-documentation-of-perl">POD - Plain Old Documentation</a></li>
 <li><a href="/debugging-perl-scripts">Perl 스크립트 디버깅</a></li>
 </ol>


### PR DESCRIPTION
This is a fix of an invalid link in perl-tutorial.

Thank you.
G.Y.Park
