### PR TITLE
Jeff's Edits

### DIFF
--- a/sites/en/pages/stringification-in-classic-perl-oop.tt
+++ b/sites/en/pages/stringification-in-classic-perl-oop.tt
@@ -27,7 +27,7 @@ means that we take an object and create a string format. It happens when the obj
 In order to change the behavior of the My::Date class when an object of that type is placed in string context,
 we need to "overload" the stringification operator. It can be done using the <a href="https://metacpan.org/pod/overload">overload</a> module.
 
-This is what need to be added to the Date.pm file in the <a href="/constructor-and-accessors-in-classic-perl-oop">previous example</a>.
+This is what needs to be added to the Date.pm file in the <a href="/constructor-and-accessors-in-classic-perl-oop">previous example</a>.
 
 <code lang="perl">
 use overload 


### PR DESCRIPTION
Although `overload` supports both, you probably want to pass a method name rather than a coderef.  Especially because this article is about OOP.
