### PR TITLE
Improve Turkish translation of 'Scalar and List context in Perl, the size of an array'

### DIFF
--- a/sites/tr/pages/scalar-and-list-context-in-perl.tt
+++ b/sites/tr/pages/scalar-and-list-context-in-perl.tt
@@ -1,7 +1,7 @@
-=title Perlde scalar ve list bağlam, bir dizinin boyutu
+=title Perl'de tekli ve çoklu bağlam, bir dizideki eleman sayısı
 =timestamp 2014-08-31T14:14:14
 =indexes scalar, list, array, size, length, context, Perl
-=status show"
+=status show
 =original scalar-and-list-context-in-perl
 =books beginner_book
 =author szabgab


### PR DESCRIPTION
Motivated by [Replacing hash keys with values does not a translation make ](http://blog.nu42.com/2014/08/replacing-hash-keys-with-values-does.html), went through the whole document and tried to make the Turkish flow a little bit more naturally as well as fixing some errors which substantially changed meaning.
