### PR TITLE
spellchecking all e* f* g* files

### DIFF
--- a/sites/en/pages/exiftool-version-and-xml-metadata.txt
+++ b/sites/en/pages/exiftool-version-and-xml-metadata.txt
@@ -100,11 +100,11 @@ While doing that, DPP "copies" XMP tags into resulting JPG file too, which is ex
 behaviour -except (as it seems), these tags cannot be modified later
 (no matter what ExifTool version being used).
 
-As you may know, Canon DPP modifies raw files too, by writting various DPP settings into file.
+As you may know, Canon DPP modifies raw files too, by writing various DPP settings into file.
 But that doesn't affect previously written XMP data inside CR2: I can modify
 XMP data in raw without problem later (after DPP wrote modify data inside CR2).
 
-So my conlusion: If XMP data exists inside CR2, Canon DPP doesn't know how to write
+So my conclusion: If XMP data exists inside CR2, Canon DPP doesn't know how to write
 that data properly into converted file.
 So,... keep on doing good work :-)
 
@@ -143,7 +143,7 @@ This would cause the EXIF to be processed, allowing the contained misplaced XMP 
 
 Posted on 2007-05-22 16:31:25-07 by bogdan in response to 5200
 
-Phil, this is genious.
+Phil, this is genius.
 If I understand you advice correctly, then I can use ifd1:iso as "dummy" tag -just to force
 ExifTool to do XMP work inside exif section. Of course in this case such
 XMP tags remain inside exif section, but at least we are able to change their content.
@@ -153,7 +153,7 @@ Following your suggestion, I was able to delete complete "old" XMP tags, by usin
 exiftool -xmp:all= ifd1:iso= my.jpg
 </code>
 
--and add new (correctly written) XMP tags... so nobody can blaim ExifTool doing something wrong :-)
+-and add new (correctly written) XMP tags... so nobody can blame ExifTool doing something wrong :-)
 
 I haven't tried, but I agree there's no point to give a note to Canon -I believe
 they use answering machines for such complains.

--- a/sites/en/pages/expect-before-and-expect-after-with-perl.txt
+++ b/sites/en/pages/expect-before-and-expect-after-with-perl.txt
@@ -1,4 +1,4 @@
-=title Expect_before amd expect_affter with perl and expect.pm
+=title Expect_before amd expect_after with perl and expect.pm
 =timestamp 2006-01-20T20:40:59
 =indexes Expect 
 =status show

--- a/sites/en/pages/extra-information-in-cannon-eos-350-cr2-after-using-digital-photo-professional.txt
+++ b/sites/en/pages/extra-information-in-cannon-eos-350-cr2-after-using-digital-photo-professional.txt
@@ -102,7 +102,7 @@ After a check of another couple of hundred untouched files it appears that the c
 never appends this string. Obviously, it's possible that this might come up inside a free-form text tag,
 but if it's possible to examine the portion of the file between the last declared block
 and the fsize idea of the file length (hmm, showing too much C there: sorry), then looking for 
-those strings and keeping the data inbetween ought to be fairly safe. ie: only accept the string 
+those strings and keeping the data in between ought to be fairly safe. ie: only accept the string 
 as a block delimiter outside of the TIFF structure.
 
 HTH,

--- a/sites/en/pages/fetching-data-from-youtube-using-perl.txt
+++ b/sites/en/pages/fetching-data-from-youtube-using-perl.txt
@@ -55,7 +55,7 @@ say $s->total_upload_views;
 </code>
 
 This would fetch my user profile - without even logging in to YouTube - and 
-print out the statistics. I have 105 subscribers, when I prepared the screencast in Jine 2011. There are 551 in July 2014.
+print out the statistics. I have 105 subscribers, when I prepared the screencast in June 2011. There are 551 in July 2014.
 
 Then I wanted to send the resulting data to myself via Gmail. Another short search on Meta CPAN
 for <b>Gmail</b> and I found <a href="http://metacpan.org/pod/Email::Send::SMTP::Gmail">Email::Send::SMTP::Gmail</a>.

--- a/sites/en/pages/geolocation-of-ip-address-using-ip2location.txt
+++ b/sites/en/pages/geolocation-of-ip-address-using-ip2location.txt
@@ -14,7 +14,7 @@ in Malaysia.
 =abstract end
 
 Their web-site has a link for <a href="http://www.ip2location.com/developers">developers</a> where they 
-link to the client libraries in varius languages, including <a href="http://www.ip2location.com/developers/perl">Perl</a>.
+link to the client libraries in various languages, including <a href="http://www.ip2location.com/developers/perl">Perl</a>.
 
 
 <h2>Install</h2>

--- a/sites/en/pages/getting-started-with-perl-dancer-on-digital-ocean.txt
+++ b/sites/en/pages/getting-started-with-perl-dancer-on-digital-ocean.txt
@@ -387,7 +387,7 @@ links to Starman
 root@s12:~# find /etc/ | grep rc| grep nginx | xargs ls -l
 </code>
 
-These commands will creat the symbolic links:
+These commands will create the symbolic links:
 
 <code>
 root@s12:~# ln -s ../init.d/starman /etc/rc0.d/K20starman

--- a/sites/en/pages/getting-started-with-perl-dancer.txt
+++ b/sites/en/pages/getting-started-with-perl-dancer.txt
@@ -11,7 +11,7 @@
 =abstract start
 
 Perl Dancer is a modern, light weight, route-oriented web application framework for Perl. In the first few minutes of this screencast,
-you will learn how to set up your development envirionment on Microsoft Windows machine, and then you will see how to create your
+you will learn how to set up your development environment on Microsoft Windows machine, and then you will see how to create your
 first (and very basic) web application using Perl Dancer <b>regardless of your operating system</b>. (14:25 min)
 
 =abstract end
@@ -60,7 +60,7 @@ The CSS file gets the following:
 
 <hl>lib/Echo.pm</li> implements the application.
 
-The defaul content was this:
+The default content was this:
 
 <code lang="perl">
 package Echo;


### PR DESCRIPTION
using this command:
for f in e*; do aspell check $f --mode=html; done
for f in f*; do aspell check $f --mode=html; done
for f in g*; do aspell check $f --mode=html; done