### PR TITLE
Add here-documents and common-warning-and-errors to pages (es)

### DIFF
--- a/sites/es/pages/errores-y-warnings-comunes.txt
+++ b/sites/es/pages/errores-y-warnings-comunes.txt
@@ -1,0 +1,46 @@
+=title Errores y warnings tipicos en Perl
+=timestamp 2015-07-04T20:22:01
+=indexes 
+=status show
+=original common-warnings-and-error-messages
+=books beginner
+=author szabgab
+=translator davidegx
+=comments_disqus_enable 1
+
+=abstract start
+
+Aunque los mensajes de error y warning en Perl son bastante precisos, a veces no son
+del todo claros para principiantes. En estos artículos verás algunos de los mensajes
+de error y warning más habituales explicados de una forma más amigable.
+
+Algunos de los artículos incluyen también indicaciones sobre como solucionar el problema.
+
+=abstract end
+
+
+<ul>
+    <li><a href="http://perlmaven.com/global-symbol-requires-explicit-package-name">Global symbol requires explicit package name (en)</a>
+         also explained in <a href="http://perlmaven.com/variable-declaration-in-perl">Variable declaration in Perl (en)</a></li>
+    <li><a href="http://perlmaven.com/use-of-uninitialized-value">Use of uninitialized value (en)</a></li>
+    <li><a href="http://perlmaven.com/barewords-in-perl">Bareword not allowed while "strict subs" in use (en)</a></li>
+    <li><a href="http://perlmaven.com/name-used-only-once-possible-typo">Name "main::x" used only once: possible typo at ... (en)</a></li>
+    <li><a href="http://perlmaven.com/unknown-warnings-category">Unknown warnings category (en)</a></li>
+    <li>Can't use string ("Foo") as a HASH ref while "strict refs" in use at ...
+       explained in <a href="/symbolic-reference-in-perl">Symbolic references in Perl (en)</a></li>
+    <li><a href="http://perlmaven.com/cant-locate-in-inc">Can't locate ... in @INC (en)</a></li>
+    <li><a href="http://perlmaven.com/scalar-found-where-operator-expected">Scalar found where operator expected (en)</a></li>
+    <li><a href="http://perlmaven.com/my-variable-masks-earlier-declaration-in-same-scope">"my" variable masks earlier declaration in same scope (en)</a></li>
+    <li><a href="http://perlmaven.com/cant-call-method-on-unblessed-reference">Can't call method ... on unblessed reference (en)</a></li>
+    <li><a href="http://perlmaven.com/argument-isnt-numeric-in-numeric">Argument ... isn't numeric in numeric ... (en)</a></li>
+    <li><a href="http://perlmaven.com/cant-locate-object-method-via-package-1">Can't locate object method "..." via package "1" (perhaps you forgot to load "1"?) (en)</a></li>
+    <li><a href="http://perlmaven.com/creating-hash-from-an-array">Odd number of elements in hash assignment (en)</a></li>
+    <li><a href="http://perlmaven.com/qw-quote-word">Possible attempt to separate words with commas (en)</a></li>
+    <li><a href="http://perlmaven.com/pro/autoload">Undefined subroutine ... called (en)</a></li>
+</ul>
+
+
+<a href="https://metacpan.org/pod/perldiag">perldiag</a> contiene explicaciones más extensas sobre cada uno de los errores y
+warnings, puedes ojear esta página o puedes acceder a una explicación especifica como se muestra en <a href="http://perlmaven.com/use-diagnostics-or-splain">usando diagnostics o splain (en)</a>.
+
+

--- a/sites/es/pages/here-documents.txt
+++ b/sites/es/pages/here-documents.txt
@@ -1,0 +1,229 @@
+=title Here documents, o como crear strings multi-línea en Perl
+=timestamp 2015-07-04T20:25:01
+=indexes <<, /m, /g, q, qq
+=status show
+=original here-documents
+=books beginner
+=author szabgab
+=translator davidegx
+=comments_disqus_enable 1
+
+=abstract start
+
+De vez en cuando puedes tener la necesidad de crear textos
+que se extienden a lo largo de varias lineas.
+Perl dispone de varias soluciones para escribir strings multi-línea, una
+de ellas es here-document (documento-aquí).
+
+=abstract end
+
+El uso de <b>here-document</b> te permite crear un texto <b>multi-línea</b> conservando
+espacios y saltos de línea. Si ejecutas el código siguiente mostrará exactamente
+lo que ves empezando por Hola hasta que aparece END_MESSAGE.
+
+<h2>Here-document no interpolado</h2>
+
+<code lang="perl">
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+my $nombre = 'Foo';
+
+my $mensaje = <<'END_MESSAGE';
+Hola $nombre,
+
+este es un mensaje que te voy a enviar.
+
+Saludos
+  Perl Maven
+END_MESSAGE
+
+print $mensaje;
+</code>
+
+Salida:
+
+<code>
+Hola $nombre,
+
+este es un mensaje que te voy a enviar.
+
+Saludos
+  Perl Maven
+</code>
+
+El here-document comienza con dos caracteres de menor que <hl>&lt;&lt;</hl> seguido de una cadena arbitraria que
+se convierte en la cadena que marca el fin del texto, y por último el punto y coma <hl>;</hl> que marca el final
+de la sentencia.
+Es un poco extraño porque realmente la sentencia no acaba aquí. El contenido del here-document
+comienza en la línea siguiente del punto y coma, en nuestro caso con la palabra "Hola", y continua hasta
+que perl encuentra la marca de fin del documento, en nuestro caso <b>END_MESSAGE</b>.
+
+Si has visto here-documents en otros sitios, puede que te sorprenda ver comillas simples
+alrededor de <b>END_MESSAGE</b>. En muchos ejemplos de código en Internet es común encontrar
+código como:
+
+<code lang="perl">
+my $mensaje = <<END_MESSAGE;
+...
+END_MESSAGE
+</code>
+
+Funciona y se comporta de la misma manera que si pusieses END_MESSAGE con comillas dobles, como en el
+siguiente ejemplo, pero este uso esta <b>deprecado</b> y será eliminado a partir de la versión 5.20 de Perl.
+¡<b>No</b> lo uses! No uses here-document sin las comillas alrededor de la marca de fin del mensaje.
+
+<code lang="perl">
+my $mensaje = <<"END_MESSAGE";
+...
+END_MESSAGE
+</code>
+
+Si ya conoces la
+<a href="/strings-entrecomillados-interpolados-y-escapados-en-perl">diferencia entre comillas simples y comillas dobles </a>
+en Perl, no te sorprenderá saber que here-documents se comporta de la misma forma.
+La única diferencia es que las comillas están alrededor de la marca de fin de texto en lugar de alrededor
+del propio texto.
+Si no se usan comillas Perl se comporta como si se usasen comillas dobles.
+
+Si miras de nuevo el primer ejemplo, verás que Perl no intentó reemplazar <hl>$nombre</hl>
+por el contenido de esa variable y que permaneció de forma literal en la salida.
+(Ni siquiera es necesario que dicha variable estuviese definida. Puedes probar de nuevo
+sin la sentencia <hl>my $nombre = 'Foo';</hl>)
+
+<h2>Here-document interpolado</h2>
+
+En el siguiente ejemplo usaremos comillas dobles alrededor de la marca de fin de texto y
+por lo tanto <hl>$nombre</hl> será reemplazado por su valor:
+
+<code lang="perl">
+use strict;
+use warnings;
+
+my $nombre = 'Foo';
+my $mensaje = <<"END_MSG";
+Hola $name,
+
+como estas?
+END_MSG
+
+print $mensaje;
+</code>
+
+El resultado de la ejecución será:
+
+<code>
+Hola Foo,
+
+como estas?
+</code>
+
+<h2>Advertencia: marca de fin idéntica al final</h2>
+
+Un pequeño apunte. Tienes que asegurarte de que la marca de fin esta duplicada al final
+del texto de forma <b>exacta</b>. Sin espacios delante o después. Sino Perl no
+reconocerá el final del texto.
+Esto quiere decir que no puedes identar la marca de fin como el resto de tu código. ¿O quizás si?
+
+<h2>Here documents y código identado</h2>
+
+Si el fragmento de código here document va en una posición donde
+normalmente identariamos el código, tenemos dos problemas:
+
+
+<code lang="perl">
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+my $name = 'Foo';
+my $send = 1;
+
+if ($send) {
+    my $mensaje = <<"END_MESSAGE";
+        Hola $name,
+    
+        este es un mensaje que planeo enviarte.
+    
+        saludos
+          Perl Maven
+END_MESSAGE
+    print $mensaje;
+}
+</code>
+
+Uno ya mencionado previamente, la marca de cierre debe ser exactamente igual
+en su declaración y al final del texto, por lo que no puedes identarlo al final.
+
+El otro problema es que la salida contendrá todos los espacios en blanco usados
+para identar:
+
+<code>
+        Hola Foo,
+    
+        este es un mensaje que planeo enviarte.
+    
+        saludos
+          Perl Maven
+</code>
+
+El problema de la falta de identación en la marca de fin se puede resolver
+incluyendo espacios suficientes delante:
+
+<code lang="perl">
+    my $mensaje = <<"    END_MESSAGE";
+       ...
+    END_MESSAGE
+</code>
+
+La identación extra se puede solucionar usando una sustitución en la asignación.
+
+<code lang="perl">
+    (my $mensaje = <<"    END_MESSAGE") =~ s/^ {8}//gm; 
+        ...
+    END_MESSAGE
+</code>
+
+En esta sustitución reemplazamos los 8 espacios al comienzo por la cadena vacía. El
+modificador <hl>/m</hl> cambia el comportamiento de <hl>^</hl> para que en lugar
+de corresponder con el <b>principio del string</b> corresponda con <b>el principio de cualquier línea</b>. El
+modificador <hl>/g</hl> sirve para hacer la sustitución <b>globalmente</b>, es decir, realizar
+la sustitución tantas veces como se encuentre el texto buscado.
+
+Estos dos flags combinados provocarán que la sustitución elimine los 8 primeros espacios de cada línea
+en la variable de la parte izquierda de <hl>=~</hl>.
+En la parte izquierda es necesario poner la asignación entre paréntesis porque la precedencia
+del operador de asignación <hl>=</hl> es menor que la precedencia de <hl>=~</hl>. Sin los
+paréntesis, perl intentaría realizar la sustitución en el here-doc y fallaría en tiempo de
+compilación:
+
+Can't modify scalar in substitution (s///) at programming.pl line 9, near "s/^ {8}//gm;"
+
+<h2>Usando q o qq</h2>
+
+Después de toda esta explicación no estoy seguro de si debería recomendar el uso de here-documents.
+En muchos casos, en lugar de here-docuemnts, uso los operadores <hl>qq</hl> o <hl>q</hl>.
+Dependiendo de si quiero interpolar o no los strings:
+
+<code lang="perl">
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+my $name = 'Foo';
+my $send = 1;
+
+if ($send) {
+    (my $mensaje = qq{
+        Hola $name,
+    
+        este es un mensaje que planeo enviarte.
+    
+        saludos
+          Perl Maven
+        }) =~ s/^ {8}//mg;
+    print $mensaje;
+}
+</code>
+

--- a/sites/es/pages/perl-tutorial.txt
+++ b/sites/es/pages/perl-tutorial.txt
@@ -54,19 +54,7 @@ en perl y otros módulos externos, que instalaremos desde <b>CPAN</b>.
 
 <b>Escalares</b>
 <ol>
-<li>Mensajes de error y advertencia comunes<br />
-  <ul>
-    <li><a href="http://perlmaven.com/global-symbol-requires-explicit-package-name">Global symbol requires explicit package name (en)</a></li>
-    <li><a href="http://perlmaven.com/use-of-uninitialized-value">Uso de valores no inicializados (en)</a></li>
-    <li><a href="http://perlmaven.com/barewords-in-perl">Bareword not allowed while "strict subs" in use (en)</a></li>
-    <li><a href="http://perlmaven.com/name-used-only-once-possible-typo">Name "main::x" used only once: possible typo at ... (en)</a></li>
-    <li><a href="http://perlmaven.com/unknown-warnings-category">Unknown warnings category (en)</a></li>
-    <li><a href="http://perlmaven.com/scalar-found-where-operator-expected">Scalar found where operator expected (en)</a></li>
-    <li><a href="http://perlmaven.com/my-variable-masks-earlier-declaration-in-same-scope">"my" variable masks earlier declaration in same scope (en)</a></li>
-    <li><a href="http://perlmaven.com/cant-call-method-on-unblessed-reference">Can't call method ... on unblessed reference (en)</a></li>
-    <li><a href="http://perlmaven.com/argument-isnt-numeric-in-numeric">Argument ... isn't numeric in numeric ... (en)</a></li>
-  </ul>
-</li>
+<li><a href="/errores-y-warnings-comunes">Errores y warnings tipicos en Perl</a></li>
 <li><a href="/conversion-automatica-de-valores-en-perl">Conversión automática de texto a número</a></li>
 <li>Sentencias condicionales: if</li>
 <li><a href="/valores-booleanos-en-perl">Valores booleanos en Perl</a></li>
@@ -74,7 +62,7 @@ en perl y otros módulos externos, que instalaremos desde <b>CPAN</b>.
 <li><a href="/operadores-string">Operadores para strings: concatenación (.) y repetición (x)</a></li>
 <li><a href="/undef-y-defined-en-perl">undef, el valor inicial y la función defined</a></li>
 <li><a href="/strings-entrecomillados-interpolados-y-escapados-en-perl">Strings en Perl: entrecomillado, interpolación y secuencias de escape</a></li>
-<li><a href="http://perlmaven.com/here-documents">Here documents (en)</a></li>
+<li><a href="/here-documents">Here documents</a></li>
 <li><a href="http://perlmaven.com/scalar-variables">Variables escalares (en)</a></li>
 <li><a href="http://perlmaven.com/comparing-scalars-in-perl">Comparando escalares (en)</a></li>
 <li><a href="http://perlmaven.com/string-functions-length-lc-uc-index-substr">Funciones para tratar Strings: length, lc, uc, index, substr (en)</a></li>
@@ -194,6 +182,24 @@ en perl y otros módulos externos, que instalaremos desde <b>CPAN</b>.
 <li><a href="http://perlmaven.com/simple-database-access-using-perl-dbi-and-sql">Acceso a base de datos usando Perl (DBI, DBD::SQLite, MySQL, PostgreSQL, ODBC) (en)</a></li>
 <li>Accediendo a LDAP usando Perl</li>
 </ol>
+<li>Mensajes de error y warnings comunes<br />
+  <ol>
+    <li><a href="http://perlmaven.com/global-symbol-requires-explicit-package-name">Global symbol requires explicit package name (en)</a></li>
+    <li><a href="http://perlmaven.com/use-of-uninitialized-value">Uso de valores no inicializados (en)</a></li>
+    <li><a href="http://perlmaven.com/barewords-in-perl">Bareword not allowed while "strict subs" in use (en)</a></li>
+    <li><a href="http://perlmaven.com/name-used-only-once-possible-typo">Name "main::x" used only once: possible typo at ... (en)</a></li>
+    <li><a href="http://perlmaven.com/unknown-warnings-category">Unknown warnings category (en)</a></li>
+    <li><a href="http://perlmaven.com/cant-locate-in-inc">Can't locate ... in @INC (en)</a></li>
+    <li><a href="http://perlmaven.com/scalar-found-where-operator-expected">Scalar found where operator expected (en)</a></li>
+    <li><a href="http://perlmaven.com/my-variable-masks-earlier-declaration-in-same-scope">"my" variable masks earlier declaration in same scope (en)</a></li>
+    <li><a href="http://perlmaven.com/cant-call-method-on-unblessed-reference">Can't call method ... on unblessed reference (en)</a></li>
+    <li><a href="http://perlmaven.com/argument-isnt-numeric-in-numeric">Argument ... isn't numeric in numeric ... (en)</a></li>
+    <li><a href="http://perlmaven.com/cant-locate-object-method-via-package-1">Can't locate object method "..." via package "1" (perhaps you forgot to load "1"?) (en)</a></li>
+    <li><a href="http://perlmaven.com/creating-hash-from-an-array">Odd number of elements in hash assignment (en)</a></li>
+    <li><a href="http://perlmaven.com/qw-quote-word">Possible attempt to separate words with commas (en)</a></li>
+    <li><a href="http://perlmaven.com/pro/autoload">Undefined subroutine ... called (en)</a></li>
+  </ol>
+</li>
 
 <b>Other</b>
 <ol>


### PR DESCRIPTION
Hi,

Just added:
* common-warnings-and-error-messages
* here-documents
to the Spanish version.

A couple of notes:

    use v5.20;
    my $x = <<END;
       bla bla bla
     END
    say $x; 

Seems to work perfectly so it is not deprecated/removed. 
I think you already know that because I've found sites/en/pages/bare-here-documents-are-deprecated.txt (just skim through it). Anyway, I'd say there are some things that need to be fixed:
* The here-documents article shouldn't be amended, the deprecated bit is misleading.
* If I use the search box and type heredoc<enter> or here-doc<enter> nothing is found.
* If I use the search box and just write 'here' and click on "Bare Here documents are deprecated..." I am redirected to http://perlmaven.com/ref, which doesn't seem related with here docs at all.

On an unrelated note, I'm going to the YAPC::Europe in Granada, so I think I'll meet you there.