### PR TITLE
Remove spaces in assignment to PERL5LIB in cmd.exe

### DIFF
--- a/sites/en/pages/how-to-change-inc-to-find-perl-modules-in-non-standard-locations.txt
+++ b/sites/en/pages/how-to-change-inc-to-find-perl-modules-in-non-standard-locations.txt
@@ -106,7 +106,7 @@ you log-in.
 On <b>Windows</b> you can set the same in the cmd command window by typing
 
 <code>
-set PERL5LIB = c:\path\to\dir
+set PERL5LIB=c:\path\to\dir
 </code>
 
 For a more long term solution follow these steps:


### PR DESCRIPTION
It turns out that the spaces around the equals sign when setting the `PERL5LIB` inside `cmd.exe` need to be removed for the assignment to work.  For instance:

    set PERL5LIB = c:\path\to\module\lib
    echo %PERL5LIB%

gives the output:

    %PERL5LIB%

Removing the spaces around the equals sign,

    set PERL5LIB=c:\path\to\module\lib
    echo %PERL5LIB%

gives

    c:\path\to\module\lib

as expected.

This was tested using Windows 7's `cmd.exe`.  Hope this helps!