### PR TITLE
Update counter-with-dancer-using-in-memory-sqlite-database.txt

### DIFF
--- a/sites/en/pages/counter-with-dancer-using-in-memory-sqlite-database.txt
+++ b/sites/en/pages/counter-with-dancer-using-in-memory-sqlite-database.txt
@@ -36,3 +36,5 @@ The data and the database is persistent among the requests that are served from 
 have more than one process) and if you need to restart the application server (e.g. Starman) then you will lose all the data.
 
 An external caching used by the application might make more sense.
+
+Using Redis for example provides persistence as well as atomic updates of the counter for performance via blocking incr().


### PR DESCRIPTION
I use Redis for this not just for persistence but because it has atomic incr() so it's just one op to add to the count.